### PR TITLE
Fix logic in product tests

### DIFF
--- a/tests/ECommerce.Application.UnitTests/Features/Products/Commands/DeleteProductCommandTests.cs
+++ b/tests/ECommerce.Application.UnitTests/Features/Products/Commands/DeleteProductCommandTests.cs
@@ -17,12 +17,17 @@ public sealed class DeleteProductCommandTests : ProductCommandsTestBase
     [Fact]
     public async Task Handle_WithExistingProduct_ShouldDeleteProduct()
     {
-        SetupProductExists(true);
+        // Arrange
+        SetupProductRepositoryGetByIdAsync(DefaultProduct);
 
+        // Act
         var result = await Handler.Handle(Command, CancellationToken.None);
 
+        // Assert
         result.Should().NotBeNull();
-        result.IsSuccess.Should().BeFalse();
+        result.IsSuccess.Should().BeTrue();
+
+        ProductRepositoryMock.Verify(x => x.Delete(DefaultProduct), Times.Once);
     }
 
     [Theory]

--- a/tests/ECommerce.Application.UnitTests/Features/Products/Queries/GetProductByIdQueryTest.cs
+++ b/tests/ECommerce.Application.UnitTests/Features/Products/Queries/GetProductByIdQueryTest.cs
@@ -20,23 +20,33 @@ public sealed class GetProductByIdQueryTest : ProductQueriesTestsBase
     [Fact]
     public async Task Handle_WithValidQuery_ShouldReturnProduct()
     {
+        // Arrange
+        SetupProductExists(true);
+
+        // Act
         var result = await Handler.Handle(Query, CancellationToken.None);
 
+        // Assert
         result.Should().NotBeNull();
-        result.IsSuccess.Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.NotFound);
-        result.Errors.Should().ContainSingle()
-            .Which.Should().Be(Localizer[ProductConsts.NotFound]);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(DefaultProduct.Id);
     }
 
     [Fact]
     public async Task Handle_WithInvalidQuery_ShouldReturnNotFound()
     {
+        // Arrange
         SetupProductExists(false);
+
+        // Act
         var result = await Handler.Handle(Query, CancellationToken.None);
 
+        // Assert
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeFalse();
         result.Status.Should().Be(ResultStatus.NotFound);
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be(Localizer[ProductConsts.NotFound]);
     }
 }


### PR DESCRIPTION
## Summary
- correct delete product command test to expect success and verify repository call
- fix get product by id query tests to cover success and failure cases

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842855f88008321a729959b1e47316c