### PR TITLE
Add unit tests for order status update command

### DIFF
--- a/tests/ECommerce.Application.UnitTests/Features/Orders/Commands/OrderCommandsTestBase.cs
+++ b/tests/ECommerce.Application.UnitTests/Features/Orders/Commands/OrderCommandsTestBase.cs
@@ -1,0 +1,65 @@
+using ECommerce.Application.Features.Orders;
+using ECommerce.Application.Helpers;
+using ECommerce.Application.Interfaces;
+
+namespace ECommerce.Application.UnitTests.Features.Orders.Commands;
+
+public abstract class OrderCommandsTestBase
+{
+    protected readonly Mock<IOrderRepository> OrderRepositoryMock;
+    protected readonly Mock<IProductRepository> ProductRepositoryMock;
+    protected readonly Mock<IOrderItemRepository> OrderItemRepositoryMock;
+    protected readonly Mock<IStockRepository> StockRepositoryMock;
+    protected readonly Mock<IIdentityService> IdentityServiceMock;
+    protected readonly Mock<ILazyServiceProvider> LazyServiceProviderMock;
+    protected readonly Mock<ILocalizationService> LocalizationServiceMock;
+    protected readonly LocalizationHelper Localizer;
+
+    protected readonly Guid UserId = Guid.Parse("e64db34c-7455-41da-b255-a9a7a46ace54");
+    protected readonly Order DefaultOrder;
+
+    protected OrderCommandsTestBase()
+    {
+        OrderRepositoryMock = new Mock<IOrderRepository>();
+        ProductRepositoryMock = new Mock<IProductRepository>();
+        OrderItemRepositoryMock = new Mock<IOrderItemRepository>();
+        StockRepositoryMock = new Mock<IStockRepository>();
+        IdentityServiceMock = new Mock<IIdentityService>();
+        LazyServiceProviderMock = new Mock<ILazyServiceProvider>();
+        LocalizationServiceMock = new Mock<ILocalizationService>();
+        Localizer = new LocalizationHelper(LocalizationServiceMock.Object);
+
+        LazyServiceProviderMock
+            .Setup(x => x.LazyGetRequiredService<LocalizationHelper>())
+            .Returns(Localizer);
+
+        SetupDefaultLocalizationMessages();
+
+        DefaultOrder = Order.Create(UserId, "Test Shipping", "Test Billing");
+    }
+
+    protected void SetupOrderRepositoryGetByIdAsync(Order? order = null)
+    {
+        OrderRepositoryMock
+            .Setup(x => x.GetByIdAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Expression<Func<IQueryable<Order>, IQueryable<Order>>>>?(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order ?? DefaultOrder);
+    }
+
+    protected void SetupDefaultLocalizationMessages()
+    {
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.NotFound)).Returns("Order not found");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.ProductNotFound)).Returns("Product not found");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.OrderCannotBeModified)).Returns("Order cannot be modified");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.OrderCannotBeCancelled)).Returns("Order cannot be cancelled");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.QuantityMustBeGreaterThanZero)).Returns("Quantity must be greater than zero");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.UserNotFound)).Returns("User not found");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.OrderItemNotFound)).Returns("Order item not found");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.ShippingAddressRequired)).Returns("Shipping address is required");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.BillingAddressRequired)).Returns("Billing address is required");
+        LocalizationServiceMock.Setup(x => x.GetLocalizedString(OrderConsts.EmptyOrder)).Returns("Order cannot be empty");
+    }
+}

--- a/tests/ECommerce.Application.UnitTests/Features/Orders/Commands/OrderStatusUpdateCommandTests.cs
+++ b/tests/ECommerce.Application.UnitTests/Features/Orders/Commands/OrderStatusUpdateCommandTests.cs
@@ -1,0 +1,46 @@
+using ECommerce.Application.Features.Orders.Commands;
+using ECommerce.Domain.Enums;
+
+namespace ECommerce.Application.UnitTests.Features.Orders.Commands;
+
+public sealed class OrderStatusUpdateCommandTests : OrderCommandsTestBase
+{
+    private readonly OrderStatusUpdateCommandHandler Handler;
+    private readonly OrderStatusUpdateCommand Command;
+
+    public OrderStatusUpdateCommandTests()
+    {
+        Command = new OrderStatusUpdateCommand(DefaultOrder.Id, OrderStatus.Processing);
+        Handler = new OrderStatusUpdateCommandHandler(
+            OrderRepositoryMock.Object,
+            LazyServiceProviderMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidTransition_ShouldUpdateStatus()
+    {
+        SetupOrderRepositoryGetByIdAsync(DefaultOrder);
+
+        var result = await Handler.Handle(Command, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        DefaultOrder.Status.Should().Be(OrderStatus.Processing);
+        OrderRepositoryMock.Verify(x => x.Update(It.Is<Order>(o => o.Status == OrderStatus.Processing)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidTransition_ShouldReturnError()
+    {
+        SetupOrderRepositoryGetByIdAsync(DefaultOrder);
+        var invalidCommand = new OrderStatusUpdateCommand(DefaultOrder.Id, OrderStatus.Delivered);
+
+        var result = await Handler.Handle(invalidCommand, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be("Invalid status transition");
+        OrderRepositoryMock.Verify(x => x.Update(It.IsAny<Order>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary
- add OrderCommandsTestBase to support order command unit tests
- add OrderStatusUpdateCommandTests covering valid and invalid status transitions

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7eff6a4832193b629c3b541d3be