### PR TITLE
Add API integration tests with Testcontainers

### DIFF
--- a/tests/ECommerce.WebAPI.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/ECommerce.WebAPI.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace ECommerce.WebAPI.IntegrationTests;
+
+public sealed class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly PostgreSqlTestcontainer _dbContainer = new TestcontainersBuilder<PostgreSqlTestcontainer>()
+        .WithDatabase(new PostgreSqlTestcontainerConfiguration
+        {
+            Database = "ecommerce",
+            Username = "postgres",
+            Password = "postgres"
+        })
+        .WithImage("postgres:16-alpine")
+        .Build();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var overrides = new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = _dbContainer.GetConnectionString(),
+                ["ConnectionStrings:Redis"] = "localhost:6379"
+            };
+            config.AddInMemoryCollection(overrides!);
+        });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+        await _dbContainer.DisposeAsync();
+    }
+}

--- a/tests/ECommerce.WebAPI.IntegrationTests/GlobalUsings.cs
+++ b/tests/ECommerce.WebAPI.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,23 @@
+global using System;
+global using System.Net;
+global using System.Net.Http.Json;
+global using System.Threading.Tasks;
+
+// xUnit & FluentAssertions
+global using Xunit;
+global using FluentAssertions;
+
+// ASP.NET Core testing
+global using Microsoft.AspNetCore.Mvc.Testing;
+global using Microsoft.Extensions.DependencyInjection;
+
+// Data access
+global using Microsoft.EntityFrameworkCore;
+
+global using DotNet.Testcontainers.Builders;
+global using DotNet.Testcontainers.Containers;
+
+// Project namespaces
+global using ECommerce.Persistence.Contexts;
+global using ECommerce.Domain.Entities;
+

--- a/tests/ECommerce.WebAPI.IntegrationTests/ProductEndpointsTests.cs
+++ b/tests/ECommerce.WebAPI.IntegrationTests/ProductEndpointsTests.cs
@@ -1,0 +1,60 @@
+namespace ECommerce.WebAPI.IntegrationTests;
+
+public class ProductEndpointsTests : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private HttpClient _client = default!;
+
+    public ProductEndpointsTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.InitializeAsync();
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await (_factory as IAsyncLifetime).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetProducts_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/Product");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CreateProduct_PersistsProduct()
+    {
+        // Arrange - create category directly
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var category = Category.Create("Integration");
+        context.Categories.Add(category);
+        await context.SaveChangesAsync();
+
+        var command = new
+        {
+            Name = "Phone",
+            Description = "Smart phone",
+            Price = 100m,
+            CategoryId = category.Id,
+            StockQuantity = 3
+        };
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/Product", command);
+        response.EnsureSuccessStatusCode();
+
+        // Assert DB
+        var product = await context.Products.Include(p => p.Stock).FirstOrDefaultAsync();
+        product.Should().NotBeNull();
+        product!.Name.Should().Be("Phone");
+        product.Stock.Quantity.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary
- create global usings for API tests
- add `CustomWebApplicationFactory` to spin up PostgreSQL with Testcontainers
- implement `ProductEndpointsTests` verifying product endpoints

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846eeddc1408321af98f29746ebf67e